### PR TITLE
Task list should hide heading bullet

### DIFF
--- a/lib/handlers/list-item.js
+++ b/lib/handlers/list-item.js
@@ -32,6 +32,7 @@ function listItem(h, node, parent) {
   var single = (!parent || !parent.loose) && head.children && children.length === 1;
   var result = all(h, single ? head : node);
   var container;
+  var props = {};
 
   if (typeof node.checked === 'boolean') {
     if (!single && head.type !== 'paragraph') {
@@ -49,11 +50,14 @@ function listItem(h, node, parent) {
       checked: node.checked,
       disabled: true
     }));
+
+    /* according to github-markdown-css, this class hides bullet. */
+    props.className = 'task-list-item';
   }
 
   if (!single && result.length) {
     result = wrap(result, true);
   }
 
-  return h(node, 'li', result);
+  return h(node, 'li', props, result);
 }

--- a/lib/handlers/list-item.js
+++ b/lib/handlers/list-item.js
@@ -52,7 +52,7 @@ function listItem(h, node, parent) {
     }));
 
     /* according to github-markdown-css, this class hides bullet. */
-    props.className = 'task-list-item';
+    props.className = ['task-list-item'];
   }
 
   if (!single && result.length) {

--- a/test/list-item.js
+++ b/test/list-item.js
@@ -50,7 +50,7 @@ test('ListItem', function (t) {
     to(u('listItem', {checked: true}, [
       u('paragraph', [u('text', 'québec')])
     ])),
-    u('element', {tagName: 'li', properties: {}}, [
+    u('element', {tagName: 'li', properties: {className: 'task-list-item'}}, [
       u('element', {
         tagName: 'input',
         properties: {
@@ -70,7 +70,7 @@ test('ListItem', function (t) {
       u('paragraph', [u('text', 'romeo')]),
       u('paragraph', [u('text', 'sierra')])
     ])),
-    u('element', {tagName: 'li', properties: {}}, [
+    u('element', {tagName: 'li', properties: {className: 'task-list-item'}}, [
       u('text', '\n'),
       u('element', {tagName: 'p', properties: {}}, [
         u('element', {
@@ -97,7 +97,7 @@ test('ListItem', function (t) {
     to(u('listItem', {checked: true}, [
       u('html', '<!--tango-->')
     ])),
-    u('element', {tagName: 'li', properties: {}}, [
+    u('element', {tagName: 'li', properties: {className: 'task-list-item'}}, [
       u('text', '\n'),
       u('element', {tagName: 'p', properties: {}}, [
         u('element', {

--- a/test/list-item.js
+++ b/test/list-item.js
@@ -50,7 +50,7 @@ test('ListItem', function (t) {
     to(u('listItem', {checked: true}, [
       u('paragraph', [u('text', 'québec')])
     ])),
-    u('element', {tagName: 'li', properties: {className: 'task-list-item'}}, [
+    u('element', {tagName: 'li', properties: {className: ['task-list-item']}}, [
       u('element', {
         tagName: 'input',
         properties: {
@@ -70,7 +70,7 @@ test('ListItem', function (t) {
       u('paragraph', [u('text', 'romeo')]),
       u('paragraph', [u('text', 'sierra')])
     ])),
-    u('element', {tagName: 'li', properties: {className: 'task-list-item'}}, [
+    u('element', {tagName: 'li', properties: {className: ['task-list-item']}}, [
       u('text', '\n'),
       u('element', {tagName: 'p', properties: {}}, [
         u('element', {
@@ -97,7 +97,7 @@ test('ListItem', function (t) {
     to(u('listItem', {checked: true}, [
       u('html', '<!--tango-->')
     ])),
-    u('element', {tagName: 'li', properties: {className: 'task-list-item'}}, [
+    u('element', {tagName: 'li', properties: {className: ['task-list-item']}}, [
       u('text', '\n'),
       u('element', {tagName: 'p', properties: {}}, [
         u('element', {


### PR DESCRIPTION
I found that task list items should hide their heading bullets.

- [x] like this :)

According to github-markdown-css, 'task-list-item' class will hide the bullets on the head of list items.

https://github.com/sindresorhus/github-markdown-css/blob/gh-pages/github-markdown.css#L666

So I added the class when a list is a task list.  I confirmed it worked well with github-markdown-css.