### PR TITLE
Add 'customHandlers' option to customize node handlers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ var footer = require('./footer');
 function factory(tree, options) {
   options = options || {};
   var dangerous = options.allowDangerousHTML;
-  var handlers = options.customHandlers;
+  var handlers = options.customHandlers || {};
 
   /**
    * Finalise the created `right`, a HAST node, from

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,9 @@ var footer = require('./footer');
  * @return {Function} - Hyperscript-like DSL.
  */
 function factory(tree, options) {
-  var dangerous = (options || {}).allowDangerousHTML;
+  options = options || {};
+  var dangerous = options.allowDangerousHTML;
+  var handlers = options.customHandlers;
 
   /**
    * Finalise the created `right`, a HAST node, from
@@ -99,6 +101,7 @@ function factory(tree, options) {
   }
 
   h.dangerous = dangerous;
+  h.customHandlers = handlers;
   h.definition = definitions(tree);
   h.footnotes = [];
   h.augment = augment;

--- a/lib/one.js
+++ b/lib/one.js
@@ -45,7 +45,8 @@ function unknown(h, node) {
  */
 function one(h, node, parent) {
   var type = node && node.type;
-  var fn = has(handlers, type) ? handlers[type] : null;
+  var defaultFn = has(handlers, type) ? handlers[type] : null;
+  var fn = has(h.customHandlers, type) ? h.customHandlers[type] : defaultFn;
 
   /* Fail on non-nodes. */
   if (!type) {

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,34 @@ Whether to allow `html` nodes and inject them as raw HTML (`boolean`,
 default: `false`).  Only do this when compiling later with
 `hast-util-to-html`.
 
+###### `options.customHandlers`
+
+It allows to define customized node handlers.
+You can customize how to transform a MDAST node to a HAST node for
+each type of node.
+
+Below is an example to add some properties to `text` node.
+
+```javascript
+var trimLines = require('trim-lines');
+var u = require('unist-builder');
+
+var handlers = {};
+handlers.text = function(h, node) {
+  var value = trimLines(node.value);
+
+  if (node.className) {
+    return h.augment(node, u('span', {className: node.className}, [u('text', value)]));
+  }
+
+  return h.augment(node, u('text', value));
+};
+
+var hast = toHAST(node, {customHandlers: handlers});
+```
+
+To see default node handlers, please see [lib/handlers](lib/handlers).
+
 ###### Returns
 
 [`HASTNode`][hast].

--- a/test/custom-handlers.js
+++ b/test/custom-handlers.js
@@ -1,0 +1,37 @@
+/**
+ * @author rhysd
+ * @copyright 2016 Titus Wormer
+ * @license MIT
+ * @module mdast-util-to-hast
+ * @fileoverview Test suite for `mdast-util-to-hast`.
+ */
+
+'use strict';
+
+/* eslint-env node */
+
+/* Dependencies. */
+var test = require('tape');
+var u = require('unist-builder');
+var trimLines = require('trim-lines');
+var to = require('..');
+
+/* Tests. */
+test('Custom handlers', function (t) {
+  var handlers = {};
+  handlers.text = function (h, node) {
+    var value = trimLines(node.value);
+
+    return h.augment(node, h(node, 'span', {className: 'custom-class'}, [u('text', value)]));
+  };
+
+  t.deepEqual(
+    to(u('text', 'this will be decorated'), {customHandlers: handlers}),
+    u('element', {tagName: 'span', properties: {className: 'custom-class'}}, [
+      u('text', 'this will be decorated')
+    ])
+  );
+
+  t.end();
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -33,3 +33,4 @@ require('./table.js');
 require('./text.js');
 require('./thematic-break.js');
 require('./yaml.js');
+require('./custom-handlers.js');


### PR DESCRIPTION
Hi again,

I added one option to this package.

I found that I could not customize transforming MDAST to HAST.  When I add an extra properties to MDAST node on transformer plugin in remark chain, I need to transform the properties to proper HAST node.  So I added 'customHandlers' option to enable it.

I added implementation, document and test.  The default value of the option is `{}` hence it doesn't break current behavior.