### PR TITLE
Add language name to class in inline code

### DIFF
--- a/lib/handlers/inline-code.js
+++ b/lib/handlers/inline-code.js
@@ -25,5 +25,12 @@ var u = require('unist-builder');
  * @return {Node} - HAST node.
  */
 function inlineCode(h, node) {
-  return h(node, 'code', [u('text', collapse(node.value))]);
+  var lang = node.lang && node.lang.match(/^[^\ \t]+(?=[\ \t]|$)/);
+  var props = {};
+
+  if (lang) {
+    props.className = ['language-' + lang];
+  }
+
+  return h(node, 'code', props, [u('text', collapse(node.value))]);
 }


### PR DESCRIPTION
Support language name for `inlineCode` type as well as code block so that we can highlight its syntax with renderer like `remark-react` for the custom inline code parsed with a plugin such as [remark-inline-math](https://github.com/bizen241/remark-inline-math).
